### PR TITLE
解耦硬编码的模型选择至配置文件

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -20,10 +20,19 @@ from maa.toolkit import Toolkit
 
 
 class AIResolver:
-    def __init__(self, api_key):
+    def __init__(
+            self,
+            api_key,
+            choice_model: str = "Qwen/Qwen2.5-7B-Instruct",
+            blank_model: str = "Qwen/Qwen2.5-7B-Instruct",
+            blank_large_model: str = "Qwen/Qwen2.5-32B-Instruct",
+    ):
         self.session = Client()
         self.session.headers = {"Authorization": f"Bearer {api_key}"}
         self.url = "https://api.siliconflow.cn/v1/chat/completions"
+        self.choice_model = choice_model
+        self.blank_model = blank_model
+        self.blank_large_model = blank_large_model
 
     @staticmethod
     def image_encode(img: np.ndarray) -> str:
@@ -49,7 +58,7 @@ class AIResolver:
 
     def resolve_choice(self, imgs: list[np.ndarray]) -> list[str] | None:
         data = {
-            "model": "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            "model": self.choice_model,
             "messages": [
                 {
                     "role": "system",
@@ -90,7 +99,7 @@ class AIResolver:
 
     def resolve_blank(self, imgs: list[np.ndarray], answer: bool, blank_num: int) -> str | None:
         data = {
-            "model": "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            "model": self.blank_model,
             "messages": [
                 {
                     "role": "system",
@@ -113,7 +122,7 @@ class AIResolver:
         }
         if not answer:
             data["messages"][0]["content"] = f"能力与角色:你是一位答题助手\n背景信息:你会得到一张包含填空题的图片\n指令:你需要阅读该图片中的问题，认真理解题目和前后文，其中答案为{blank_num}个字符，思考后作出回答，确保填入答案后的全文逻辑正确，语义正确\n输出风格:你无需给出推理过程，也无需给出任何解释。你只需要回答空缺处应当填的内容，填充字数应当为{blank_num}"
-            data["model"] = "Qwen/Qwen2.5-VL-32B-Instruct"
+            data["model"] = self.blank_large_model
         response = self.session.post(self.url, json=data)
         try:
             if response.status_code == 200:
@@ -132,17 +141,43 @@ resource.post_bundle("./resource").wait()
 
 
 class MaaWorker:
-    def __init__(self, queue: SimpleQueue, api_key):
+    def __init__(
+            self,
+            queue: SimpleQueue,
+            api_key,
+            choice_model: str | None = None,
+            blank_model: str | None = None,
+            blank_large_model: str | None = None,
+    ):
         user_path = "./"
         Toolkit.init_option(user_path)
 
         self.queue = queue
         self.tasker = Tasker()
         self.connected = False
-        self.ai_resolver = AIResolver(api_key=api_key)
+        self.api_key = api_key
+        self.ai_resolver = AIResolver(
+            api_key=api_key,
+            choice_model=choice_model or "Qwen/Qwen2.5-7B-Instruct",
+            blank_model=blank_model or "Qwen/Qwen2.5-7B-Instruct",
+            blank_large_model=blank_large_model or "Qwen/Qwen2.5-32B-Instruct",
+        )
         self.stop_flag = False
         self.pause_flag = False
         self.send_log("MAA初始化成功")
+
+    def update_ai_models(
+            self,
+            choice_model: str | None = None,
+            blank_model: str | None = None,
+            blank_large_model: str | None = None,
+    ):
+        self.ai_resolver = AIResolver(
+            api_key=self.api_key,
+            choice_model=choice_model or self.ai_resolver.choice_model,
+            blank_model=blank_model or self.ai_resolver.blank_model,
+            blank_large_model=blank_large_model or self.ai_resolver.blank_large_model,
+        )
 
     def send_log(self, msg):
         self.queue.put(f"{time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())} {msg}")

--- a/utils.py
+++ b/utils.py
@@ -158,9 +158,9 @@ class MaaWorker:
         self.api_key = api_key
         self.ai_resolver = AIResolver(
             api_key=api_key,
-            choice_model=choice_model or "Qwen/Qwen2.5-7B-Instruct",
-            blank_model=blank_model or "Qwen/Qwen2.5-7B-Instruct",
-            blank_large_model=blank_large_model or "Qwen/Qwen2.5-32B-Instruct",
+            choice_model=choice_model or "Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_model=blank_model or "Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_large_model=blank_large_model or "Qwen/Qwen2.5-VL-32B-Instruct",
         )
         self.stop_flag = False
         self.pause_flag = False

--- a/utils.py
+++ b/utils.py
@@ -23,9 +23,9 @@ class AIResolver:
     def __init__(
             self,
             api_key,
-            choice_model: str = "Qwen/Qwen2.5-7B-Instruct",
-            blank_model: str = "Qwen/Qwen2.5-7B-Instruct",
-            blank_large_model: str = "Qwen/Qwen2.5-32B-Instruct",
+            choice_model: str = "Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_model: str = "Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_large_model: str = "Qwen/Qwen2.5-VL-32B-Instruct",
     ):
         self.session = Client()
         self.session.headers = {"Authorization": f"Bearer {api_key}"}

--- a/webui.py
+++ b/webui.py
@@ -16,6 +16,9 @@ from utils import MaaWorker
 
 class ConfigModel(BaseModel):
     api_key: str
+    choice_model: str | None = None
+    blank_model: str | None = None
+    blank_large_model: str | None = None
 
 class DeviceModel(BaseModel):
     name: str
@@ -55,7 +58,13 @@ def get_settings():
     with open("./config/config.json") as f:
         config = json.load(f)
     if config["api_key"] != "" and app_state.worker is None:
-        app_state.worker = MaaWorker(app_state.message_conn,api_key=config["api_key"])
+        app_state.worker = MaaWorker(
+            app_state.message_conn,
+            api_key=config["api_key"],
+            choice_model=config.get("choice_model"),
+            blank_model=config.get("blank_model"),
+            blank_large_model=config.get("blank_large_model")
+        )
     return config
 
 @app.post("/api/settings")
@@ -63,7 +72,20 @@ def post_settings(config: ConfigModel):
     with open("./config/config.json", "w") as f:
         f.write(config.model_dump_json(indent=4))
     if app_state.worker is None:
-        app_state.worker = MaaWorker(app_state.message_conn, api_key=config.api_key)
+        app_state.worker = MaaWorker(
+            app_state.message_conn,
+            api_key=config.api_key,
+            choice_model=config.choice_model,
+            blank_model=config.blank_model,
+            blank_large_model=config.blank_large_model
+        )
+    else:
+        # 如果worker已存在，更新其模型配置
+        app_state.worker.update_ai_models(
+            choice_model=config.choice_model,
+            blank_model=config.blank_model,
+            blank_large_model=config.blank_large_model
+        )
     return {"status": "success"}
 
 @app.get("/api/get_device")


### PR DESCRIPTION
refactor(utils): 解耦硬编码的模型选择至配置文件

- 因硅基流动 Qwen2.5 接口似乎暂时不可用，将模型选择逻辑从代码库中解耦。
- 将模型配置项移至 config 中，以便用户可以手动修改和切换模型，方便测试各个模型。

[Warning]: 本次提交的逻辑代码由 AI 辅助生成，目前尚未测试，请暂时不要合并。

## Summary by Sourcery

通过使模型选择可配置并可在运行时更新，解耦硬编码的 AI 模型标识符。

增强内容：
- 允许 `AIResolver` 接收可配置的模型名称，而不是使用硬编码的 Qwen 模型标识符。
- 使 `MaaWorker` 能够接受初始 AI 模型配置，并在无需修改调用方代码的情况下动态更新 AI 模型选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple hard-coded AI model identifiers by making model selection configurable and updatable at runtime.

Enhancements:
- Allow AIResolver to receive configurable model names instead of using hard-coded Qwen model identifiers.
- Enable MaaWorker to accept initial AI model configuration and to update AI model options dynamically without changing caller code.

</details>

增强内容：
- 允许 AIResolver 和 MaaWorker 接受可配置的模型名称，而不是使用硬编码的 Qwen 模型标识符。
- 在 MaaWorker 上新增一个方法，用于动态更新 AI 模型选项，而无需修改调用端代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过使模型选择可配置并可在运行时更新，解耦硬编码的 AI 模型标识符。

增强内容：
- 允许 `AIResolver` 接收可配置的模型名称，而不是使用硬编码的 Qwen 模型标识符。
- 使 `MaaWorker` 能够接受初始 AI 模型配置，并在无需修改调用方代码的情况下动态更新 AI 模型选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple hard-coded AI model identifiers by making model selection configurable and updatable at runtime.

Enhancements:
- Allow AIResolver to receive configurable model names instead of using hard-coded Qwen model identifiers.
- Enable MaaWorker to accept initial AI model configuration and to update AI model options dynamically without changing caller code.

</details>

</details>