### PR TITLE
将模型选择从硬编码移至配置文件

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,3 +1,4 @@
 {
-    "api_key": ""
+    "api_key": "",
+    "model": "Qwen/Qwen3.6-35B-A3B"
 }

--- a/utils.py
+++ b/utils.py
@@ -20,10 +20,19 @@ from maa.toolkit import Toolkit
 
 
 class AIResolver:
-    def __init__(self, api_key):
+    def __init__(
+            self,
+            api_key,
+            choice_model: str = "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_model: str = "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_large_model: str = "Qwen/Qwen2.5-VL-32B-Instruct",
+    ):
         self.session = Client()
         self.session.headers = {"Authorization": f"Bearer {api_key}"}
         self.url = "https://api.siliconflow.cn/v1/chat/completions"
+        self.choice_model = choice_model
+        self.blank_model = blank_model
+        self.blank_large_model = blank_large_model
 
     @staticmethod
     def image_encode(img: np.ndarray) -> str:
@@ -49,7 +58,7 @@ class AIResolver:
 
     def resolve_choice(self, imgs: list[np.ndarray]) -> list[str] | None:
         data = {
-            "model": "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            "model": self.choice_model,
             "messages": [
                 {
                     "role": "system",
@@ -90,7 +99,7 @@ class AIResolver:
 
     def resolve_blank(self, imgs: list[np.ndarray], answer: bool, blank_num: int) -> str | None:
         data = {
-            "model": "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            "model": self.blank_model,
             "messages": [
                 {
                     "role": "system",
@@ -113,7 +122,7 @@ class AIResolver:
         }
         if not answer:
             data["messages"][0]["content"] = f"能力与角色:你是一位答题助手\n背景信息:你会得到一张包含填空题的图片\n指令:你需要阅读该图片中的问题，认真理解题目和前后文，其中答案为{blank_num}个字符，思考后作出回答，确保填入答案后的全文逻辑正确，语义正确\n输出风格:你无需给出推理过程，也无需给出任何解释。你只需要回答空缺处应当填的内容，填充字数应当为{blank_num}"
-            data["model"] = "Qwen/Qwen2.5-VL-32B-Instruct"
+            data["model"] = self.blank_large_model
         response = self.session.post(self.url, json=data)
         try:
             if response.status_code == 200:
@@ -132,17 +141,43 @@ resource.post_bundle("./resource").wait()
 
 
 class MaaWorker:
-    def __init__(self, queue: SimpleQueue, api_key):
+    def __init__(
+            self,
+            queue: SimpleQueue,
+            api_key,
+            choice_model: str | None = None,
+            blank_model: str | None = None,
+            blank_large_model: str | None = None,
+    ):
         user_path = "./"
         Toolkit.init_option(user_path)
 
         self.queue = queue
         self.tasker = Tasker()
         self.connected = False
-        self.ai_resolver = AIResolver(api_key=api_key)
+        self.api_key = api_key
+        self.ai_resolver = AIResolver(
+            api_key=api_key,
+            choice_model=choice_model or "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_model=blank_model or "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+            blank_large_model=blank_large_model or "Qwen/Qwen2.5-VL-32B-Instruct",
+        )
         self.stop_flag = False
         self.pause_flag = False
         self.send_log("MAA初始化成功")
+
+    def update_ai_models(
+            self,
+            choice_model: str | None = None,
+            blank_model: str | None = None,
+            blank_large_model: str | None = None,
+    ):
+        self.ai_resolver = AIResolver(
+            api_key=self.api_key,
+            choice_model=choice_model or self.ai_resolver.choice_model,
+            blank_model=blank_model or self.ai_resolver.blank_model,
+            blank_large_model=blank_large_model or self.ai_resolver.blank_large_model,
+        )
 
     def send_log(self, msg):
         self.queue.put(f"{time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())} {msg}")

--- a/utils.py
+++ b/utils.py
@@ -23,16 +23,12 @@ class AIResolver:
     def __init__(
             self,
             api_key,
-            choice_model: str = "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
-            blank_model: str = "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
-            blank_large_model: str = "Qwen/Qwen2.5-VL-32B-Instruct",
+            model,
     ):
         self.session = Client()
         self.session.headers = {"Authorization": f"Bearer {api_key}"}
         self.url = "https://api.siliconflow.cn/v1/chat/completions"
-        self.choice_model = choice_model
-        self.blank_model = blank_model
-        self.blank_large_model = blank_large_model
+        self.model = model
 
     @staticmethod
     def image_encode(img: np.ndarray) -> str:
@@ -58,7 +54,7 @@ class AIResolver:
 
     def resolve_choice(self, imgs: list[np.ndarray]) -> list[str] | None:
         data = {
-            "model": self.choice_model,
+            "model": self.model,
             "messages": [
                 {
                     "role": "system",
@@ -99,7 +95,7 @@ class AIResolver:
 
     def resolve_blank(self, imgs: list[np.ndarray], answer: bool, blank_num: int) -> str | None:
         data = {
-            "model": self.blank_model,
+            "model": self.model,
             "messages": [
                 {
                     "role": "system",
@@ -122,17 +118,17 @@ class AIResolver:
         }
         if not answer:
             data["messages"][0]["content"] = f"能力与角色:你是一位答题助手\n背景信息:你会得到一张包含填空题的图片\n指令:你需要阅读该图片中的问题，认真理解题目和前后文，其中答案为{blank_num}个字符，思考后作出回答，确保填入答案后的全文逻辑正确，语义正确\n输出风格:你无需给出推理过程，也无需给出任何解释。你只需要回答空缺处应当填的内容，填充字数应当为{blank_num}"
-            data["model"] = self.blank_large_model
+            data["model"] = self.model
         response = self.session.post(self.url, json=data)
         try:
             if response.status_code == 200:
                 result = response.json()
-                answer = result["choices"][0]["message"]["content"]
+                result = result["choices"][0]["message"]["content"]
             else:
-                answer = None
+                result = None
         except:
-            answer = None
-        return answer
+            result = None
+        return result
 
 
 resource = Resource()
@@ -145,9 +141,7 @@ class MaaWorker:
             self,
             queue: SimpleQueue,
             api_key,
-            choice_model: str | None = None,
-            blank_model: str | None = None,
-            blank_large_model: str | None = None,
+            model: str,
     ):
         user_path = "./"
         Toolkit.init_option(user_path)
@@ -158,9 +152,7 @@ class MaaWorker:
         self.api_key = api_key
         self.ai_resolver = AIResolver(
             api_key=api_key,
-            choice_model=choice_model or "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
-            blank_model=blank_model or "Pro/Qwen/Qwen2.5-VL-7B-Instruct",
-            blank_large_model=blank_large_model or "Qwen/Qwen2.5-VL-32B-Instruct",
+            model=model,
         )
         self.stop_flag = False
         self.pause_flag = False
@@ -168,19 +160,15 @@ class MaaWorker:
 
     def update_ai_models(
             self,
-            choice_model: str | None = None,
-            blank_model: str | None = None,
-            blank_large_model: str | None = None,
+            model: str | None = None,
     ):
         self.ai_resolver = AIResolver(
             api_key=self.api_key,
-            choice_model=choice_model or self.ai_resolver.choice_model,
-            blank_model=blank_model or self.ai_resolver.blank_model,
-            blank_large_model=blank_large_model or self.ai_resolver.blank_large_model,
+            model=model or self.ai_resolver.model,
         )
 
     def send_log(self, msg):
-        self.queue.put(f"{time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())} {msg}")
+        self.queue.put(f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} {msg}")
         time.sleep(0.05)
 
     def pause(self):

--- a/webui.py
+++ b/webui.py
@@ -16,9 +16,7 @@ from utils import MaaWorker
 
 class ConfigModel(BaseModel):
     api_key: str
-    choice_model: str | None = None
-    blank_model: str | None = None
-    blank_large_model: str | None = None
+    model: str = "Qwen/Qwen3.6-35B-A3B"
 
 class DeviceModel(BaseModel):
     name: str
@@ -61,9 +59,7 @@ def get_settings():
         app_state.worker = MaaWorker(
             app_state.message_conn,
             api_key=config["api_key"],
-            choice_model=config.get("choice_model"),
-            blank_model=config.get("blank_model"),
-            blank_large_model=config.get("blank_large_model")
+            model=config["model"],
         )
     return config
 
@@ -75,16 +71,11 @@ def post_settings(config: ConfigModel):
         app_state.worker = MaaWorker(
             app_state.message_conn,
             api_key=config.api_key,
-            choice_model=config.choice_model,
-            blank_model=config.blank_model,
-            blank_large_model=config.blank_large_model
+            model=config.model,
         )
     else:
-        # 如果worker已存在，更新其模型配置
         app_state.worker.update_ai_models(
-            choice_model=config.choice_model,
-            blank_model=config.blank_model,
-            blank_large_model=config.blank_large_model
+            model=config.model
         )
     return {"status": "success"}
 

--- a/webui.py
+++ b/webui.py
@@ -16,6 +16,9 @@ from utils import MaaWorker
 
 class ConfigModel(BaseModel):
     api_key: str
+    choice_model: str | None = None
+    blank_model: str | None = None
+    blank_large_model: str | None = None
 
 class DeviceModel(BaseModel):
     name: str
@@ -55,7 +58,13 @@ def get_settings():
     with open("./config/config.json") as f:
         config = json.load(f)
     if config["api_key"] != "" and app_state.worker is None:
-        app_state.worker = MaaWorker(app_state.message_conn,api_key=config["api_key"])
+        app_state.worker = MaaWorker(
+            app_state.message_conn,
+            api_key=config["api_key"],
+            choice_model=config.get("choice_model"),
+            blank_model=config.get("blank_model"),
+            blank_large_model=config.get("blank_large_model")
+        )
     return config
 
 @app.post("/api/settings")
@@ -63,7 +72,20 @@ def post_settings(config: ConfigModel):
     with open("./config/config.json", "w") as f:
         f.write(config.model_dump_json(indent=4))
     if app_state.worker is None:
-        app_state.worker = MaaWorker(app_state.message_conn, api_key=config.api_key)
+        app_state.worker = MaaWorker(
+            app_state.message_conn,
+            api_key=config.api_key,
+            choice_model=config.choice_model,
+            blank_model=config.blank_model,
+            blank_large_model=config.blank_large_model
+        )
+    else:
+        # 如果worker已存在，更新其模型配置
+        app_state.worker.update_ai_models(
+            choice_model=config.choice_model,
+            blank_model=config.blank_model,
+            blank_large_model=config.blank_large_model
+        )
     return {"status": "success"}
 
 @app.get("/api/get_device")


### PR DESCRIPTION
经测试，我发现之前的qwen2.5调用已经返回不存在的模型，不知道是新注册的账号还是啥原因。
先暂时将硬编码改成可配置，这样方便改个模型用。

我不会写代码所以代码是ai写的，需要谨慎。不过经过测试目前是能用的。
测试使用模型：Qwen/Qwen3.5-9B和Qwen/Qwen3.6-35B-A3B，基本能满足要求

希望能解决 #7

## Summary by Sourcery

通过配置文件和网页界面配置 Qwen 模型选择，而不是在 worker 和 resolver 中硬编码默认值。

新功能：
- 通过配置和 Web API，为选择题、普通填空题和大型填空任务分别配置独立的模型。

增强：
- 重构 AIResolver 和 MaaWorker，使其接受模型标识作为参数，并通过 API 在运行时根据已保存的设置更新这些标识。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Qwen model selection configurable via the config file and web UI instead of hardcoding defaults in the worker and resolver.

New Features:
- Allow separate configurable models for choice questions, normal fill-in-the-blank questions, and large fill-in-the-blank tasks via config and web API.

Enhancements:
- Refactor AIResolver and MaaWorker to accept model identifiers as parameters and expose an API to update them at runtime based on saved settings.

</details>

新功能：
- 允许通过配置文件和 API 为选择题、普通填空题和大型填空任务分别配置不同的模型。
- 在 Web 配置模式中暴露模型选择选项，使用户无需修改代码即可自定义底层 Qwen 模型。

改进：
- 重构 AIResolver 和 MaaWorker，使其能够动态接收和更新模型标识符，并在未指定时保留之前的默认设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过配置文件和网页界面配置 Qwen 模型选择，而不是在 worker 和 resolver 中硬编码默认值。

新功能：
- 通过配置和 Web API，为选择题、普通填空题和大型填空任务分别配置独立的模型。

增强：
- 重构 AIResolver 和 MaaWorker，使其接受模型标识作为参数，并通过 API 在运行时根据已保存的设置更新这些标识。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Qwen model selection configurable via the config file and web UI instead of hardcoding defaults in the worker and resolver.

New Features:
- Allow separate configurable models for choice questions, normal fill-in-the-blank questions, and large fill-in-the-blank tasks via config and web API.

Enhancements:
- Refactor AIResolver and MaaWorker to accept model identifiers as parameters and expose an API to update them at runtime based on saved settings.

</details>

</details>